### PR TITLE
[FEAT] Custom OAuth + JWT 로그인 방식 구현, closes #1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.3'
+    id 'org.springframework.boot' version '3.3.1'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -32,6 +32,9 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
     // queryDSL
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
@@ -40,7 +43,7 @@ dependencies {
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
     // Swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.3'
 
     // S3
     implementation 'software.amazon.awssdk:s3:2.30.0'

--- a/src/main/java/com/gongspot/project/global/auth/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/gongspot/project/global/auth/CustomOAuth2SuccessHandler.java
@@ -1,0 +1,36 @@
+package com.gongspot.project.global.auth;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public CustomOAuth2SuccessHandler(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+            throws IOException, ServletException {
+
+        // OAuth2User 정보
+        String email = ((org.springframework.security.oauth2.core.user.OAuth2User) authentication.getPrincipal()).getAttribute("email");
+
+        // JWT 발급
+        String token = jwtTokenProvider.createToken(email);
+
+        // JSON 형태로 응답
+        response.setContentType("application/json");
+        response.setCharacterEncoding("utf-8");
+        response.getWriter().write("{\"access token\": \"" + token + "\"}");
+    }
+}

--- a/src/main/java/com/gongspot/project/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/gongspot/project/global/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,43 @@
+package com.gongspot.project.global.auth;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            // 인증 성공 시 SecurityContextHolder 설정
+            SecurityContextHolder.getContext().setAuthentication(jwtTokenProvider.getAuthentication(token));
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/gongspot/project/global/auth/JwtTokenProvider.java
+++ b/src/main/java/com/gongspot/project/global/auth/JwtTokenProvider.java
@@ -1,0 +1,63 @@
+package com.gongspot.project.global.auth;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    private final long validityInMilliseconds = 1000 * 60 * 60; // 1시간
+
+    @PostConstruct
+    protected void init() {
+        this.secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
+    }
+
+    public String createToken(String email) {
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + validityInMilliseconds);
+
+        return Jwts.builder()
+                .setSubject(email)
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public Authentication getAuthentication(String token) {
+        String email = Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+
+        return new UsernamePasswordAuthenticationToken(email, "", Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")));
+    }
+}

--- a/src/main/java/com/gongspot/project/global/config/SecurityConfig.java
+++ b/src/main/java/com/gongspot/project/global/config/SecurityConfig.java
@@ -1,0 +1,47 @@
+package com.gongspot.project.global.config;
+
+import com.gongspot.project.global.auth.CustomOAuth2SuccessHandler;
+import com.gongspot.project.global.auth.JwtAuthenticationFilter;
+import com.gongspot.project.global.auth.JwtTokenProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    public static final String[] allowedUrls = {
+            "/",
+            "/swagger-ui/**",
+            "/swagger-resources/**",
+            "/v3/api-docs/**",
+            "/api/v1/posts/**",
+            "/api/v1/replies/**",
+            "/login",
+            "/auth/login/kakao/**"
+    };
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http, CustomOAuth2SuccessHandler customOAuth2SuccessHandler, JwtTokenProvider jwtTokenProvider) throws Exception {
+        http
+                .authorizeHttpRequests(authorizeRequests ->
+                        authorizeRequests
+                                .requestMatchers(allowedUrls).permitAll()  // 허용 URL 설정
+                                .anyRequest().authenticated()  // 그 외 모든 요청은 인증 필요
+                )
+                .csrf(csrf -> csrf.disable())
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable())
+                .oauth2Login(oauth2 -> oauth2
+                        .successHandler(customOAuth2SuccessHandler)
+                );
+
+        http.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}
+

--- a/src/main/java/com/gongspot/project/global/config/SwaggerConfig.java
+++ b/src/main/java/com/gongspot/project/global/config/SwaggerConfig.java
@@ -1,14 +1,21 @@
 package com.gongspot.project.global.config;
 
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
-import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
 
+@SecurityScheme(
+        name = "BearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT"
+)
 @Configuration
 public class SwaggerConfig {
 
@@ -19,14 +26,14 @@ public class SwaggerConfig {
                 .description("공스팟 Server API 명세서")
                 .version("1.0.0");
 
-        String jwtSchemeName = "JWT TOKEN";
+        String jwtSchemeName = "BearerAuth";
         // 헤더에 인증정보 포함
         SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
         // SecuritySchemes 등록
         Components components = new Components()
-                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                .addSecuritySchemes(jwtSchemeName, new io.swagger.v3.oas.models.security.SecurityScheme()
                         .name(jwtSchemeName)
-                        .type(SecurityScheme.Type.HTTP)
+                        .type(io.swagger.v3.oas.models.security.SecurityScheme.Type.HTTP)
                         .scheme("bearer")
                         .bearerFormat("JWT"));
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,5 @@
 spring.application.name=project
 
-spring.security.user.name=admin
-spring.security.user.password=1234
-
 spring.datasource.url=jdbc:mysql://localhost:3306/${DB_NAME}
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
@@ -16,3 +13,21 @@ spring.jpa.properties.hibernate.default_batch_fetch_size=1000
 
 logging.level.org.hibernate.SQL=INFO
 logging.level.org.hibernate.type.descriptor.sql=TRACE
+
+# OAuth2 provider ??
+spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kakao.com/oauth/authorize
+spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/oauth/token
+spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
+spring.security.oauth2.client.provider.kakao.user-name-attribute=id
+
+# OAuth2 registration ??
+spring.security.oauth2.client.registration.kakao.client-id=${OAUTH-RESTAPI-KEY}
+spring.security.oauth2.client.registration.kakao.client-secret=
+spring.security.oauth2.client.registration.kakao.redirect-uri=http://localhost:8080/login/oauth2/code/kakao
+spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.kakao.client-authentication-method=client_secret_post
+spring.security.oauth2.client.registration.kakao.client-name=Kakao
+spring.security.oauth2.client.registration.kakao.scope=profile_nickname,profile_image,account_email
+
+# jwt ?? ??
+jwt.secret=${JWT-SECRET-KEY}


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- #1 

## ⚡️ 작업동기

- 카카오 oauth2 로그인 + JWT 토큰 기반의 커스텀 로그인 방식 구현하였습니다.
- 이후 refresh token 도입할지 여부와 프론트와 논의하여 현재 반환하는 형식 수정하면 될 것 같습니다.

## 🔑 주요 변경사항

- 모듈 의존성 관련한 버전 조정 (swagger 세팅 관련)
- customoauth2handler, jwtauthenticationfilter, securityconfig 등의 코드 작성
- 프론트단에서 _http://localhost:8080/oauth2/authorization/kakao_ 사용하여 접근 가능하도록 설계하였습니다.

![image](https://github.com/user-attachments/assets/e7627c86-434f-408d-aef1-de7a082d64c6)
![image](https://github.com/user-attachments/assets/053b92e9-9cec-42ae-b577-979f1ec34017)


## 💡 관련 이슈

- https://m.blog.naver.com/seek316/223349824088
- 

## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!
