### PR TITLE
[FEAT] 공지사항 목록조회 api 구현 , closes #15

### DIFF
--- a/src/main/java/com/gongspot/project/common/code/status/ErrorStatus.java
+++ b/src/main/java/com/gongspot/project/common/code/status/ErrorStatus.java
@@ -27,6 +27,9 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //Place Error
     PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE4001", "장소를 찾을 수 없습니다."),
+
+    //Notification Error
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION4001", "공지사항을 찾을 수 없습니다.");
     ; // 위에 적을 것 !
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/gongspot/project/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/gongspot/project/domain/notification/controller/NotificationController.java
@@ -1,0 +1,29 @@
+package com.gongspot.project.domain.notification.controller;
+
+import com.gongspot.project.common.response.ApiResponse;
+import com.gongspot.project.domain.notification.service.NotificationQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import com.gongspot.project.domain.notification.dto.NotificationResponseDTO;
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/notifications")
+@Tag(name = "Notification")
+@Validated
+public class NotificationController {
+
+    private final NotificationQueryService notificationQueryService;
+
+    @Operation(summary = "공지사항 목록 조회")
+    @GetMapping("")
+    public ApiResponse<NotificationResponseDTO.NotificationListDTO> getNotificationList() {
+        NotificationResponseDTO.NotificationListDTO result = notificationQueryService.getNotificationList();
+        return ApiResponse.onSuccess(result);
+    }
+
+}

--- a/src/main/java/com/gongspot/project/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/gongspot/project/domain/notification/controller/NotificationController.java
@@ -21,7 +21,7 @@ public class NotificationController {
     private final NotificationQueryService notificationQueryService;
 
     @Operation(summary = "공지사항 목록 조회")
-    @GetMapping("")
+    @GetMapping
     public ApiResponse<NotificationResponseDTO.NotificationListDTO> getNotificationList() {
         NotificationResponseDTO.NotificationListDTO result = notificationQueryService.getNotificationList();
         return ApiResponse.onSuccess(result);

--- a/src/main/java/com/gongspot/project/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/gongspot/project/domain/notification/controller/NotificationController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import com.gongspot.project.domain.notification.dto.NotificationResponseDTO;
@@ -23,6 +24,14 @@ public class NotificationController {
     @GetMapping("")
     public ApiResponse<NotificationResponseDTO.NotificationListDTO> getNotificationList() {
         NotificationResponseDTO.NotificationListDTO result = notificationQueryService.getNotificationList();
+        return ApiResponse.onSuccess(result);
+    }
+
+    @Operation(summary = "공지사항 상세 조회")
+    @GetMapping("/{notificationId}")
+    public ApiResponse<NotificationResponseDTO.NotificationDetailDTO> getNotificationDetail(
+            @PathVariable Long notificationId) {
+        NotificationResponseDTO.NotificationDetailDTO result = notificationQueryService.getNotificationDetail(notificationId);
         return ApiResponse.onSuccess(result);
     }
 

--- a/src/main/java/com/gongspot/project/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/com/gongspot/project/domain/notification/converter/NotificationConverter.java
@@ -24,4 +24,13 @@ public class NotificationConverter {
                 .notificationList(notificationItemDTOList)
                 .build();
     }
+
+    public static NotificationResponseDTO.NotificationDetailDTO toNotificationDetailDTO(Notification notification) {
+        return NotificationResponseDTO.NotificationDetailDTO.builder()
+                .notificationId(notification.getId())
+                .date(notification.getDate())
+                .title(notification.getTitle())
+                .content(notification.getContent())
+                .build();
+    }
 }

--- a/src/main/java/com/gongspot/project/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/com/gongspot/project/domain/notification/converter/NotificationConverter.java
@@ -3,14 +3,18 @@ package com.gongspot.project.domain.notification.converter;
 import com.gongspot.project.domain.notification.dto.NotificationResponseDTO;
 import com.gongspot.project.domain.notification.entity.Notification;
 
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class NotificationConverter {
     public static NotificationResponseDTO.NotificationItemDTO toNotificationItemDTO(Notification notification) {
+
+        String formattedDate = notification.getDate().format(DateTimeFormatter.ofPattern("yy.MM.dd"));
+
         return NotificationResponseDTO.NotificationItemDTO.builder()
                 .notificationId(notification.getId())
-                .date(notification.getDate())
+                .date(formattedDate)
                 .title(notification.getTitle())
                 .build();
     }
@@ -26,9 +30,11 @@ public class NotificationConverter {
     }
 
     public static NotificationResponseDTO.NotificationDetailDTO toNotificationDetailDTO(Notification notification) {
+        String formattedDate = notification.getDate().format(DateTimeFormatter.ofPattern("yy.MM.dd"));
+
         return NotificationResponseDTO.NotificationDetailDTO.builder()
                 .notificationId(notification.getId())
-                .date(notification.getDate())
+                .date(formattedDate)
                 .title(notification.getTitle())
                 .content(notification.getContent())
                 .build();

--- a/src/main/java/com/gongspot/project/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/com/gongspot/project/domain/notification/converter/NotificationConverter.java
@@ -1,0 +1,27 @@
+package com.gongspot.project.domain.notification.converter;
+
+import com.gongspot.project.domain.notification.dto.NotificationResponseDTO;
+import com.gongspot.project.domain.notification.entity.Notification;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class NotificationConverter {
+    public static NotificationResponseDTO.NotificationItemDTO toNotificationItemDTO(Notification notification) {
+        return NotificationResponseDTO.NotificationItemDTO.builder()
+                .notificationId(notification.getId())
+                .date(notification.getDate())
+                .title(notification.getTitle())
+                .build();
+    }
+
+    public static NotificationResponseDTO.NotificationListDTO toNotificationListResultDTO(List<Notification> notificationList) {
+        List<NotificationResponseDTO.NotificationItemDTO> notificationItemDTOList = notificationList.stream()
+                .map(NotificationConverter::toNotificationItemDTO)
+                .collect(Collectors.toList());
+
+        return NotificationResponseDTO.NotificationListDTO.builder()
+                .notificationList(notificationItemDTOList)
+                .build();
+    }
+}

--- a/src/main/java/com/gongspot/project/domain/notification/dto/NotificationResponseDTO.java
+++ b/src/main/java/com/gongspot/project/domain/notification/dto/NotificationResponseDTO.java
@@ -1,0 +1,29 @@
+package com.gongspot.project.domain.notification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class NotificationResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class NotificationItemDTO {
+        private Long notificationId;
+        private LocalDate date;
+        private String title;
+    }
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class NotificationListDTO {
+        private List<NotificationItemDTO> notificationList;
+    }
+}

--- a/src/main/java/com/gongspot/project/domain/notification/dto/NotificationResponseDTO.java
+++ b/src/main/java/com/gongspot/project/domain/notification/dto/NotificationResponseDTO.java
@@ -16,7 +16,7 @@ public class NotificationResponseDTO {
     @AllArgsConstructor
     public static class NotificationItemDTO {
         private Long notificationId;
-        private LocalDate date;
+        private String date;
         private String title;
     }
     @Builder
@@ -33,7 +33,7 @@ public class NotificationResponseDTO {
     @AllArgsConstructor
     public static class NotificationDetailDTO {
         private Long notificationId;
-        private LocalDate date;
+        private String date;
         private String title;
         private String content;
     }

--- a/src/main/java/com/gongspot/project/domain/notification/dto/NotificationResponseDTO.java
+++ b/src/main/java/com/gongspot/project/domain/notification/dto/NotificationResponseDTO.java
@@ -26,4 +26,15 @@ public class NotificationResponseDTO {
     public static class NotificationListDTO {
         private List<NotificationItemDTO> notificationList;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class NotificationDetailDTO {
+        private Long notificationId;
+        private LocalDate date;
+        private String title;
+        private String content;
+    }
 }

--- a/src/main/java/com/gongspot/project/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/gongspot/project/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,11 @@
+package com.gongspot.project.domain.notification.repository;
+
+import com.gongspot.project.domain.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findAllByOrderByCreatedAtDesc();
+
+}

--- a/src/main/java/com/gongspot/project/domain/notification/service/NotificationQueryService.java
+++ b/src/main/java/com/gongspot/project/domain/notification/service/NotificationQueryService.java
@@ -1,0 +1,7 @@
+package com.gongspot.project.domain.notification.service;
+
+import com.gongspot.project.domain.notification.dto.NotificationResponseDTO;
+
+public interface NotificationQueryService {
+    NotificationResponseDTO.NotificationListDTO getNotificationList();
+}

--- a/src/main/java/com/gongspot/project/domain/notification/service/NotificationQueryService.java
+++ b/src/main/java/com/gongspot/project/domain/notification/service/NotificationQueryService.java
@@ -4,4 +4,5 @@ import com.gongspot.project.domain.notification.dto.NotificationResponseDTO;
 
 public interface NotificationQueryService {
     NotificationResponseDTO.NotificationListDTO getNotificationList();
+    NotificationResponseDTO.NotificationDetailDTO getNotificationDetail(Long notificationId);
 }

--- a/src/main/java/com/gongspot/project/domain/notification/service/NotificationQueryServiceImpl.java
+++ b/src/main/java/com/gongspot/project/domain/notification/service/NotificationQueryServiceImpl.java
@@ -1,11 +1,13 @@
 package com.gongspot.project.domain.notification.service;
 
+import com.gongspot.project.common.exception.BusinessException;
 import com.gongspot.project.domain.notification.converter.NotificationConverter;
 import com.gongspot.project.domain.notification.dto.NotificationResponseDTO;
 import com.gongspot.project.domain.notification.entity.Notification;
 import com.gongspot.project.domain.notification.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import com.gongspot.project.common.code.status.ErrorStatus;
 
 import java.util.List;
 
@@ -19,5 +21,14 @@ public class NotificationQueryServiceImpl implements NotificationQueryService{
         List<Notification> notificationList = notificationRepository.findAllByOrderByCreatedAtDesc();
 
         return NotificationConverter.toNotificationListResultDTO(notificationList);
+    }
+
+    @Override
+    public NotificationResponseDTO.NotificationDetailDTO getNotificationDetail(Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new BusinessException(ErrorStatus.NOTIFICATION_NOT_FOUND));
+
+
+        return NotificationConverter.toNotificationDetailDTO(notification);
     }
 }

--- a/src/main/java/com/gongspot/project/domain/notification/service/NotificationQueryServiceImpl.java
+++ b/src/main/java/com/gongspot/project/domain/notification/service/NotificationQueryServiceImpl.java
@@ -1,0 +1,23 @@
+package com.gongspot.project.domain.notification.service;
+
+import com.gongspot.project.domain.notification.converter.NotificationConverter;
+import com.gongspot.project.domain.notification.dto.NotificationResponseDTO;
+import com.gongspot.project.domain.notification.entity.Notification;
+import com.gongspot.project.domain.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationQueryServiceImpl implements NotificationQueryService{
+    private final NotificationRepository notificationRepository;
+
+    @Override
+    public NotificationResponseDTO.NotificationListDTO getNotificationList() {
+        List<Notification> notificationList = notificationRepository.findAllByOrderByCreatedAtDesc();
+
+        return NotificationConverter.toNotificationListResultDTO(notificationList);
+    }
+}


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- feature/15

## ⚡️ 작업동기

- 공지사항 목록조회 및 공지사항 상세조회 

## 🔑 주요 변경사항

- GET /notifications API 개발
 공지사항이 많지않을거같아서 페이징 조회 없이 전체 목록 조회로 만들었는데 이부분 나중에 페이징 추가되면 바꾸면 될거같습니다!

- GET /notifications/{notificationId} API 개발

## 💡 관련 이슈
#15 

![image](https://github.com/user-attachments/assets/671cc7e8-2c1a-4763-b9f8-396cf2808c65)
![image](https://github.com/user-attachments/assets/b9b5bf5a-0ce6-4f19-adad-61f178b8f82b)

