### PR TITLE
[FEAT] 공간 리뷰목록조회 api 구현 , closes #22

### DIFF
--- a/src/main/generated/com/gongspot/project/domain/review/entity/QReview.java
+++ b/src/main/generated/com/gongspot/project/domain/review/entity/QReview.java
@@ -26,6 +26,8 @@ public class QReview extends EntityPathBase<Review> {
 
     public final EnumPath<com.gongspot.project.common.enums.CongestionEnum> congestion = createEnum("congestion", com.gongspot.project.common.enums.CongestionEnum.class);
 
+    public final StringPath content = createString("content");
+
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
 

--- a/src/main/java/com/gongspot/project/common/code/status/ErrorStatus.java
+++ b/src/main/java/com/gongspot/project/common/code/status/ErrorStatus.java
@@ -27,8 +27,15 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //Place Error
     PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE4001", "장소를 찾을 수 없습니다."),
-    LIKE_NOT_FOUND(HttpStatus.NOT_FOUND,"LIKE4001","해당 장소에 찜한 기록이 없습니다." );
-    // 위에 적을 것 !
+    LIKE_NOT_FOUND(HttpStatus.NOT_FOUND,"LIKE4001","해당 장소에 찜한 기록이 없습니다." ),
+
+    //Review Error
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW4001", "리뷰를 찾을 수 없습니다."),
+    REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "REVIEW4002", "이미 해당 장소에 리뷰를 작성했습니다."),
+
+    //Media Error
+    MEDIA_NOT_FOUND(HttpStatus.NOT_FOUND, "MEDIA4001", "미디어를 찾을 수 없습니다."),
+    ;// 위에 적을 것 !
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/gongspot/project/domain/media/repository/MediaRepository.java
+++ b/src/main/java/com/gongspot/project/domain/media/repository/MediaRepository.java
@@ -1,0 +1,12 @@
+package com.gongspot.project.domain.media.repository;
+
+import com.gongspot.project.domain.media.entity.Media;
+import com.gongspot.project.domain.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.*;
+
+public interface MediaRepository extends JpaRepository<Media, Long> {
+    List<Media> findAllByReviewIn(List<Review> reviews);
+    Optional<Media> findByReview(Review review);
+}

--- a/src/main/java/com/gongspot/project/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/gongspot/project/domain/place/controller/PlaceController.java
@@ -4,6 +4,8 @@ import com.gongspot.project.common.response.ApiResponse;
 import com.gongspot.project.domain.place.dto.PlaceResponseDTO;
 import com.gongspot.project.domain.place.service.PlaceCommandService;
 import com.gongspot.project.domain.place.service.PlaceQueryService;
+import com.gongspot.project.domain.review.dto.ReviewResponseDTO;
+import com.gongspot.project.domain.review.service.ReviewQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -21,6 +23,7 @@ public class PlaceController {
 
     private final PlaceQueryService placeQueryService;
     private final PlaceCommandService placeCommandService;
+    private final ReviewQueryService reviewQueryService;
     private final AuthenticatedUserUtils authenticatedUserUtils;
 
     @SecurityRequirement(name = "bearerAuth")
@@ -32,6 +35,16 @@ public class PlaceController {
 
         PlaceResponseDTO.GetPlaceDTO result = placeQueryService.getPlace(userId,placeId);
 
+        return ApiResponse.onSuccess(result);
+    }
+
+    @Operation(summary = "공간 리뷰목록 조회", description = "특정 공간의 리뷰 목록을 15개씩 페이징하여 조회합니다.")
+    @GetMapping("/{placeId}/reviews")
+    public ApiResponse<ReviewResponseDTO.GetReviewListDTO> getReviewList(
+            @PathVariable Long placeId,
+            @RequestParam(defaultValue = "0") int page) {
+
+        ReviewResponseDTO.GetReviewListDTO result = reviewQueryService.getReviewList(placeId, page);
         return ApiResponse.onSuccess(result);
     }
 

--- a/src/main/java/com/gongspot/project/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/gongspot/project/domain/place/repository/PlaceRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface PlaceRepository extends JpaRepository<Place, Long> {
-    Optional<Place> findById(Long placeid);
+    Optional<Place> findById(Long placeId);
 }

--- a/src/main/java/com/gongspot/project/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/com/gongspot/project/domain/review/converter/ReviewConverter.java
@@ -1,0 +1,131 @@
+package com.gongspot.project.domain.review.converter;
+
+import com.gongspot.project.common.enums.FacilitiesEnum;
+import com.gongspot.project.common.enums.MoodEnum;
+import com.gongspot.project.common.enums.PurposeEnum;
+import com.gongspot.project.domain.media.entity.Media;
+import com.gongspot.project.domain.review.dto.ReviewResponseDTO;
+import com.gongspot.project.domain.review.entity.Review;
+
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class ReviewConverter {
+
+    public static ReviewResponseDTO.GetReviewDTO toGetReviewDTO(Review review, List<Media> reviewMediaList) {
+
+        List<String> imageUrls = new ArrayList<>();
+        if (reviewMediaList != null && !reviewMediaList.isEmpty()) {
+            imageUrls = reviewMediaList.stream()
+                    .map(Media::getUrl)
+                    .collect(Collectors.toList());
+        }
+
+        return ReviewResponseDTO.GetReviewDTO.builder()
+                .reviewId(review.getId())
+                .userId(review.getUser().getId())
+                .nickname(review.getUser().getNickname())
+                .profileImageUrl(review.getUser().getProfileImg())
+                .datetime(review.getCreatedAt().format(DateTimeFormatter.ofPattern("yy.MM.dd")))
+                .rating(review.getRating())
+                .reviewImageUrl(imageUrls)
+                .content(review.getContent())
+                .build();
+    }
+
+    public static ReviewResponseDTO.RatingPercentageDTO toRatingPercentageDTO(Map<Integer, Long> ratingCounts, long totalCount) {
+        return ReviewResponseDTO.RatingPercentageDTO.builder()
+                .fiveStarPercentage(calculatePercentage(ratingCounts.getOrDefault(5, 0L), totalCount))
+                .fourStarPercentage(calculatePercentage(ratingCounts.getOrDefault(4, 0L), totalCount))
+                .threeStarPercentage(calculatePercentage(ratingCounts.getOrDefault(3, 0L), totalCount))
+                .twoStarPercentage(calculatePercentage(ratingCounts.getOrDefault(2, 0L), totalCount))
+                .oneStarPercentage(calculatePercentage(ratingCounts.getOrDefault(1, 0L), totalCount))
+                .build();
+    }
+
+
+    public static List<ReviewResponseDTO.CategoryCountDTO> toCategoryListDTO(List<Review> reviews) {
+        Map<PurposeEnum, Long> purposeCounts = reviews.stream()
+                .flatMap(review -> review.getPurpose().stream())
+                .collect(Collectors.groupingBy(purpose -> purpose, Collectors.counting()));
+
+        PurposeEnum topPurpose = purposeCounts.entrySet().stream()
+                .max(Map.Entry.comparingByValue())
+                .map(Map.Entry::getKey)
+                .orElse(null);
+
+        Map<MoodEnum, Long> moodCounts = reviews.stream()
+                .flatMap(review -> review.getMood().stream())
+                .collect(Collectors.groupingBy(mood -> mood, Collectors.counting()));
+
+        List<MoodEnum> topMoods = moodCounts.entrySet().stream()
+                .sorted(Map.Entry.<MoodEnum, Long>comparingByValue().reversed())
+                .limit(2)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+
+        Map<FacilitiesEnum, Long> facilitiesCounts = reviews.stream()
+                .flatMap(review -> review.getFacilities().stream())
+                .collect(Collectors.groupingBy(facility -> facility, Collectors.counting()));
+
+        FacilitiesEnum topFacility = facilitiesCounts.entrySet().stream()
+                .max(Map.Entry.comparingByValue())
+                .map(Map.Entry::getKey)
+                .orElse(null);
+
+        List<ReviewResponseDTO.CategoryCountDTO> categoryList = new ArrayList<>();
+
+        if (topPurpose != null) {
+            categoryList.add(ReviewResponseDTO.CategoryCountDTO.builder()
+                    .category(topPurpose.name())
+                    .count(purposeCounts.get(topPurpose).intValue())
+                    .build());
+        }
+
+        for (MoodEnum mood : topMoods) {
+            categoryList.add(ReviewResponseDTO.CategoryCountDTO.builder()
+                    .category(mood.name())
+                    .count(moodCounts.get(mood).intValue())
+                    .build());
+        }
+
+        if (topFacility != null) {
+            categoryList.add(ReviewResponseDTO.CategoryCountDTO.builder()
+                    .category(topFacility.name())
+                    .count(facilitiesCounts.get(topFacility).intValue())
+                    .build());
+        }
+
+        return categoryList;
+    }
+
+    public static ReviewResponseDTO.GetReviewListDTO toGetReviewListDTO(
+            List<Review> reviews,
+            List<Media> mediaList,
+            Double averageRating,
+            List<ReviewResponseDTO.CategoryCountDTO> categoryList,
+            Map<Integer, Long> ratingCounts) {
+
+        Map<Long, List<Media>> reviewMediaMap = mediaList.stream()
+                .collect(Collectors.groupingBy(media -> media.getReview().getId()));
+
+
+        List<ReviewResponseDTO.GetReviewDTO> reviewDTOs = reviews.stream()
+                .map(review -> toGetReviewDTO(review, reviewMediaMap.getOrDefault(review.getId(), new ArrayList<>())))
+                .collect(Collectors.toList());
+
+        return ReviewResponseDTO.GetReviewListDTO.builder()
+                .reviewCount(reviews.size())
+                .averageRating(averageRating)
+                .ratingPercentages(toRatingPercentageDTO(ratingCounts, reviews.size()))
+                .categoryList(categoryList)
+                .reviewList(reviewDTOs)
+                .build();
+    }
+
+    private static Double calculatePercentage(Long count, long total) {
+        if (total == 0) return 0.0;
+        return (count * 100.0) / total;
+    }
+}

--- a/src/main/java/com/gongspot/project/domain/review/dto/ReviewResponseDTO.java
+++ b/src/main/java/com/gongspot/project/domain/review/dto/ReviewResponseDTO.java
@@ -1,0 +1,56 @@
+package com.gongspot.project.domain.review.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+public class ReviewResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetReviewDTO {
+        Long reviewId;
+        Long userId;
+        String nickname;
+        String profileImageUrl;
+        String datetime;
+        Integer rating;
+        List<String> reviewImageUrl;
+        String content;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RatingPercentageDTO {
+        Double fiveStarPercentage;
+        Double fourStarPercentage;
+        Double threeStarPercentage;
+        Double twoStarPercentage;
+        Double oneStarPercentage;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CategoryCountDTO {
+        private String category;
+        private Integer count;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetReviewListDTO {
+        Integer reviewCount;
+        Double averageRating;
+        RatingPercentageDTO ratingPercentages;
+        List<CategoryCountDTO> categoryList;
+        List<GetReviewDTO> reviewList;
+    }
+}

--- a/src/main/java/com/gongspot/project/domain/review/entity/Review.java
+++ b/src/main/java/com/gongspot/project/domain/review/entity/Review.java
@@ -51,6 +51,9 @@ public class Review extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private List<FacilitiesEnum> facilities;
 
+    @Column(name = "content", length = 500)
+    private String content;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;

--- a/src/main/java/com/gongspot/project/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/gongspot/project/domain/review/repository/ReviewRepository.java
@@ -12,16 +12,15 @@ import java.util.List;
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query("""
         SELECT AVG(r.rating)
-        FROM Media m
-        JOIN m.review r
-        WHERE m.place.id = :placeId
+        FROM Review r
+        WHERE r.place.id = :placeId
     """)
     Double getAverageRatingByPlaceId(@Param("placeId") Long placeId);
 
     @Query("""
-        SELECT r FROM Media m
-        JOIN m.review r
-        WHERE m.place.id = :placeId
+        SELECT r
+        FROM Review r
+        WHERE r.place.id = :placeId
         ORDER BY r.datetime DESC
     """)
     List<Review> findTop3ByPlaceId(@Param("placeId") Long placeId, Pageable pageable);

--- a/src/main/java/com/gongspot/project/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/gongspot/project/domain/review/repository/ReviewRepository.java
@@ -1,13 +1,17 @@
 package com.gongspot.project.domain.review.repository;
 
 import com.gongspot.project.domain.media.entity.Media;
+import com.gongspot.project.domain.place.entity.Place;
 import com.gongspot.project.domain.review.entity.Review;
+import com.gongspot.project.domain.user.entity.User;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query("""
@@ -24,4 +28,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
         ORDER BY r.datetime DESC
     """)
     List<Review> findTop3ByPlaceId(@Param("placeId") Long placeId, Pageable pageable);
+
+    Page<Review> findAllByPlaceOrderByCreatedAtDesc(Place place, Pageable pageable);
+    Optional<Review> findByUserAndPlace(User user, Place place);
+    List<Review> findAllByPlace(Place place);
 }

--- a/src/main/java/com/gongspot/project/domain/review/service/ReviewQueryService.java
+++ b/src/main/java/com/gongspot/project/domain/review/service/ReviewQueryService.java
@@ -1,0 +1,7 @@
+package com.gongspot.project.domain.review.service;
+
+import com.gongspot.project.domain.review.dto.ReviewResponseDTO;
+
+public interface ReviewQueryService {
+    ReviewResponseDTO.GetReviewListDTO getReviewList(Long placeId, int page);
+}

--- a/src/main/java/com/gongspot/project/domain/review/service/ReviewQueryServiceImpl.java
+++ b/src/main/java/com/gongspot/project/domain/review/service/ReviewQueryServiceImpl.java
@@ -1,0 +1,58 @@
+package com.gongspot.project.domain.review.service;
+
+import com.gongspot.project.common.code.status.ErrorStatus;
+import com.gongspot.project.common.exception.BusinessException;
+import com.gongspot.project.domain.media.entity.Media;
+import com.gongspot.project.domain.media.repository.MediaRepository;
+import com.gongspot.project.domain.place.entity.Place;
+import com.gongspot.project.domain.place.repository.PlaceRepository;
+import com.gongspot.project.domain.review.converter.ReviewConverter;
+import com.gongspot.project.domain.review.dto.ReviewResponseDTO;
+import com.gongspot.project.domain.review.entity.Review;
+import com.gongspot.project.domain.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewQueryServiceImpl implements ReviewQueryService{
+    private final ReviewRepository reviewRepository;
+    private final MediaRepository mediaRepository;
+    private final PlaceRepository placeRepository;
+
+    @Override
+    public ReviewResponseDTO.GetReviewListDTO getReviewList(Long placeId, int page) {
+        Place place = placeRepository.findById(placeId)
+                .orElseThrow(() -> new BusinessException(ErrorStatus.PLACE_NOT_FOUND));
+
+        List<Review> allReviews = reviewRepository.findAllByPlace(place);
+
+        List<Review> pagedReviews = reviewRepository.findAllByPlaceOrderByCreatedAtDesc(
+                place, PageRequest.of(page, 15)).getContent();
+
+        List<Media> mediaList = mediaRepository.findAllByReviewIn(allReviews);
+
+        Double averageRating = allReviews.stream()
+                .mapToDouble(Review::getRating)
+                .average()
+                .orElse(0.0);
+
+        Map<Integer, Long> ratingCounts = allReviews.stream()
+                .collect(Collectors.groupingBy(Review::getRating, Collectors.counting()));
+
+        List<ReviewResponseDTO.CategoryCountDTO> categoryList = ReviewConverter.toCategoryListDTO(allReviews);
+
+        return ReviewConverter.toGetReviewListDTO(
+                pagedReviews,
+                mediaList,
+                averageRating,
+                categoryList,
+                ratingCounts
+        );
+    }
+
+}


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- feature/22

## ⚡️ 작업동기

- 공간 리뷰들과 전체 평점, 리뷰 총개수 등 조회하는 api입니다 

## 🔑 주요 변경사항

 - GET /places/{placeId}/reviews?page=0 API 개발
   해당 API는 장소에 종속적인 리뷰 리소스이므로 `PlaceController` 내부에 구현하여 컨트롤러 책임과 리소스 계층 구조의 일관성을 유지했습니다
  리뷰들은 페이징 기능을 사용하였고 평균평점, 평점별 비율, 카테고리별 인기항목등을 같이 조회합니다  

수정부분
refactor : 리뷰 쿼리 수정 (Media 조인 제거 하고 Place직접참조)
review엔티티에 content(500)없어서 수정 
## 💡 관련 이슈

- #22 

