### PR TITLE
[FEAT] 장소 제안 상세 조회 api

### DIFF
--- a/src/main/java/com/gongspot/project/domain/newplace/controller/NewPlaceController.java
+++ b/src/main/java/com/gongspot/project/domain/newplace/controller/NewPlaceController.java
@@ -23,5 +23,14 @@ public class NewPlaceController {
     ) {
         NewPlaceResponseDTO result = newPlaceCommandService.createNewPlaceProposal(requestDTO);
         return ApiResponse.onSuccess(result);
+    };
+
+    @Operation(summary = "공간 등록 요청 조회")
+    @GetMapping("/proposal/{proposalId}")
+    public ApiResponse<NewPlaceResponseDTO> getNewPlaceProposal(
+            @PathVariable Long proposalId
+    ) {
+        NewPlaceResponseDTO result = newPlaceCommandService.getProposal(proposalId);
+        return ApiResponse.onSuccess(result);
     }
 }

--- a/src/main/java/com/gongspot/project/domain/newplace/dto/NewPlaceResponseDTO.java
+++ b/src/main/java/com/gongspot/project/domain/newplace/dto/NewPlaceResponseDTO.java
@@ -1,13 +1,37 @@
 package com.gongspot.project.domain.newplace.dto;
 
-import lombok.Builder;
-import lombok.Getter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.gongspot.project.domain.newplace.entity.NewPlace;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
-@Getter
+@Data
 @Builder
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class NewPlaceResponseDTO {
     private Long proposalId;
+    private String name;
+    private String link;
+    private String reason;
     private LocalDateTime createdAt;
+
+    public static NewPlaceResponseDTO fromBasic(NewPlace newPlace) {
+        return NewPlaceResponseDTO.builder()
+                .proposalId(newPlace.getId())
+                .createdAt(newPlace.getCreatedAt())
+                .build();
+    }
+
+    public static NewPlaceResponseDTO fromFull(NewPlace newPlace) {
+        return NewPlaceResponseDTO.builder()
+                .proposalId(newPlace.getId())
+                .name(newPlace.getName())
+                .link(newPlace.getLink())
+                .reason(newPlace.getReason())
+                .createdAt(newPlace.getCreatedAt())
+                .build();
+    }
+
 }

--- a/src/main/java/com/gongspot/project/domain/newplace/entity/NewPlace.java
+++ b/src/main/java/com/gongspot/project/domain/newplace/entity/NewPlace.java
@@ -34,4 +34,5 @@ public class NewPlace extends BaseEntity {
          this.link = link;
          this.reason = reason;
      }
+
 }

--- a/src/main/java/com/gongspot/project/domain/newplace/service/NewPlaceCommandService.java
+++ b/src/main/java/com/gongspot/project/domain/newplace/service/NewPlaceCommandService.java
@@ -5,4 +5,5 @@ import com.gongspot.project.domain.newplace.dto.NewPlaceResponseDTO;
 
 public interface NewPlaceCommandService {
     NewPlaceResponseDTO createNewPlaceProposal(NewPlaceRequestDTO requestDTO);
+    NewPlaceResponseDTO getProposal(Long proposalId);
 }

--- a/src/main/java/com/gongspot/project/domain/newplace/service/NewPlaceCommandServiceImpl.java
+++ b/src/main/java/com/gongspot/project/domain/newplace/service/NewPlaceCommandServiceImpl.java
@@ -25,9 +25,13 @@ public class NewPlaceCommandServiceImpl implements NewPlaceCommandService {
 
         NewPlace saved = newPlaceRepository.save(newPlace);
 
-        return NewPlaceResponseDTO.builder()
-                .proposalId(saved.getId())
-                .createdAt(saved.getCreatedAt())
-                .build();
+        return NewPlaceResponseDTO.fromBasic(saved);
+    }
+
+    @Override
+    public NewPlaceResponseDTO getProposal(Long proposalId) {
+        return newPlaceRepository.findById(proposalId)
+                .map(NewPlaceResponseDTO::fromFull)
+                .orElseThrow(() -> new IllegalArgumentException("Proposal not found"));
     }
 }


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- feature/39, #39

## ⚡️ 작업동기

- 장소 제안을 상세조회 합니다.

## 🔑 주요 변경사항

- GET /api/admin/new-places/{proposalId} API 추가
- NewPlaceCommandServiceImpl#getProposal() 구현
- NewPlaceResponseDTO.fromFull() 메서드 사용
- 장소 제안 엔티티에서 필요한 필드 (name, link, reason, createdAt)를 상세 응답에 포함
- NewPlaceResponseDTO에 정적 팩토리 메서드 fromBasic(), fromFull() 추가
- DTO에 @JsonInclude(JsonInclude.Include.NON_NULL) 설정으로 필요한 필드만 응답

## 💡 관련 이슈

- X, api 명세서 추가해두겠습니다.

## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!
