### PR TITLE
[FEAT] 공간 등록 목록 조회 api

### DIFF
--- a/src/main/java/com/gongspot/project/common/code/PageInfo.java
+++ b/src/main/java/com/gongspot/project/common/code/PageInfo.java
@@ -1,4 +1,4 @@
-package com.gongspot.project.domain.point.dto;
+package com.gongspot.project.common.code;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/gongspot/project/common/code/PageResponse.java
+++ b/src/main/java/com/gongspot/project/common/code/PageResponse.java
@@ -1,4 +1,4 @@
-package com.gongspot.project.domain.point.dto;
+package com.gongspot.project.common.code;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/gongspot/project/domain/newplace/controller/NewPlaceController.java
+++ b/src/main/java/com/gongspot/project/domain/newplace/controller/NewPlaceController.java
@@ -1,13 +1,23 @@
 package com.gongspot.project.domain.newplace.controller;
 
+import com.gongspot.project.common.code.PageResponse;
 import com.gongspot.project.common.response.ApiResponse;
 import com.gongspot.project.domain.newplace.dto.NewPlaceRequestDTO;
 import com.gongspot.project.domain.newplace.dto.NewPlaceResponseDTO;
+import com.gongspot.project.domain.newplace.entity.NewPlace;
+import com.gongspot.project.domain.newplace.repository.NewPlaceRepository;
 import com.gongspot.project.domain.newplace.service.NewPlaceCommandService;
+import com.gongspot.project.domain.point.dto.PointHistoryDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.*;
+
+import java.awt.print.Pageable;
+import java.util.List;
 
 @RestController
 @RequestMapping("/places")
@@ -15,6 +25,7 @@ import org.springframework.web.bind.annotation.*;
 public class NewPlaceController {
 
     private final NewPlaceCommandService newPlaceCommandService;
+    private final NewPlaceRepository newPlaceRepository;
 
     @Operation(summary = "새 공간 등록 신청")
     @PostMapping("/proposal")
@@ -25,12 +36,22 @@ public class NewPlaceController {
         return ApiResponse.onSuccess(result);
     };
 
-    @Operation(summary = "공간 등록 요청 조회")
+    @Operation(summary = "공간 등록 요청 상세 조회")
     @GetMapping("/proposal/{proposalId}")
     public ApiResponse<NewPlaceResponseDTO> getNewPlaceProposal(
             @PathVariable Long proposalId
     ) {
         NewPlaceResponseDTO result = newPlaceCommandService.getProposal(proposalId);
+        return ApiResponse.onSuccess(result);
+    }
+
+    @Operation(summary = "공간 등록 요청 목록 조회 (관리자)")
+    @GetMapping("/proposal")
+    public ApiResponse<PageResponse<NewPlaceResponseDTO>> getNewPlaces(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        PageResponse<NewPlaceResponseDTO> result = newPlaceCommandService.getProposals(page, size);
         return ApiResponse.onSuccess(result);
     }
 }

--- a/src/main/java/com/gongspot/project/domain/newplace/service/NewPlaceCommandService.java
+++ b/src/main/java/com/gongspot/project/domain/newplace/service/NewPlaceCommandService.java
@@ -1,9 +1,11 @@
 package com.gongspot.project.domain.newplace.service;
 
+import com.gongspot.project.common.code.PageResponse;
 import com.gongspot.project.domain.newplace.dto.NewPlaceRequestDTO;
 import com.gongspot.project.domain.newplace.dto.NewPlaceResponseDTO;
 
 public interface NewPlaceCommandService {
     NewPlaceResponseDTO createNewPlaceProposal(NewPlaceRequestDTO requestDTO);
     NewPlaceResponseDTO getProposal(Long proposalId);
+    PageResponse<NewPlaceResponseDTO> getProposals(int page, int size);
 }

--- a/src/main/java/com/gongspot/project/domain/newplace/service/NewPlaceCommandServiceImpl.java
+++ b/src/main/java/com/gongspot/project/domain/newplace/service/NewPlaceCommandServiceImpl.java
@@ -1,12 +1,19 @@
 package com.gongspot.project.domain.newplace.service;
 
+import com.gongspot.project.common.code.PageResponse;
 import com.gongspot.project.domain.newplace.dto.NewPlaceRequestDTO;
 import com.gongspot.project.domain.newplace.dto.NewPlaceResponseDTO;
 import com.gongspot.project.domain.newplace.entity.NewPlace;
 import com.gongspot.project.domain.newplace.repository.NewPlaceRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -33,5 +40,15 @@ public class NewPlaceCommandServiceImpl implements NewPlaceCommandService {
         return newPlaceRepository.findById(proposalId)
                 .map(NewPlaceResponseDTO::fromFull)
                 .orElseThrow(() -> new IllegalArgumentException("Proposal not found"));
+    }
+
+    public PageResponse<NewPlaceResponseDTO> getProposals(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<NewPlace> pageResult = newPlaceRepository.findAll(pageable);
+        List<NewPlaceResponseDTO> dtoList = pageResult.getContent().stream()
+                .map(NewPlaceResponseDTO::fromFull)
+                .toList();
+
+        return PageResponse.of(pageResult, dtoList);
     }
 }


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- #39 

## ⚡️ 작업동기

- 관리자가 등록된 공간 제안 목록을 페이지 단위로 조회할 수 있도록 기능을 구현하였습니다.

## 🔑 주요 변경사항

- GET /api/admin/new-places/proposal API 추가
- page, size 파라미터로 페이지네이션 지원 (폴더 이동)
- NewPlaceCommandServiceImpl#getProposals(int page, int size) 구현
- Page<NewPlace> → List<NewPlaceResponseDTO> 변환
- PageResponse<T> 포맷으로 래핑하여 반환

## 💡 관련 이슈

x

## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!
