### PR TITLE
[REFACTOR] 인가코드 받아 로그인하도록 추가, closes #69

### DIFF
--- a/src/main/java/com/gongspot/project/domain/user/service/UserService.java
+++ b/src/main/java/com/gongspot/project/domain/user/service/UserService.java
@@ -34,5 +34,12 @@ public class UserService {
         return userRepository.save(user);
     }
 
+    public User findOrCreateUser(String email, String nickname, String profileImageUrl) {
+        User existing = findByEmail(email);
+        if (existing != null) return existing;
+
+        return createUser(email, nickname, profileImageUrl);
+    }
+
 
 }

--- a/src/main/java/com/gongspot/project/global/auth/dto/TokenResponseDTO.java
+++ b/src/main/java/com/gongspot/project/global/auth/dto/TokenResponseDTO.java
@@ -2,12 +2,18 @@ package com.gongspot.project.global.auth.dto;
 
 public class TokenResponseDTO {
     private final String accessToken;
+    private final String refreshToken;
 
-    public TokenResponseDTO(String accessToken) {
+    public TokenResponseDTO(String accessToken, String refreshToken) {
         this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
     }
 
     public String getAccessToken() {
         return accessToken;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
     }
 }

--- a/src/main/java/com/gongspot/project/global/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/gongspot/project/global/auth/filter/JwtAuthenticationFilter.java
@@ -33,7 +33,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 path.startsWith("/v3/api-docs") ||
                 path.equals("/error") ||
                 path.equals("/auth/login") ||
-                path.equals("/auth/logout");
+                path.equals("/auth/logout") ||
+                path.equals("/auth/oauth/kakao/callback");
     }
 
     @Override

--- a/src/main/java/com/gongspot/project/global/auth/service/OAuthKakaoService.java
+++ b/src/main/java/com/gongspot/project/global/auth/service/OAuthKakaoService.java
@@ -1,0 +1,65 @@
+package com.gongspot.project.global.auth.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class OAuthKakaoService {
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${jwt.secret}")
+    private String clientSecret;
+
+    private final ObjectMapper objectMapper;
+    private final RestTemplate restTemplate;
+
+    public String getAccessToken(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", clientId);
+        body.add("redirect_uri", redirectUri);
+        body.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+        ResponseEntity<String> response = restTemplate.postForEntity("https://kauth.kakao.com/oauth/token", request, String.class);
+
+        try {
+            Map<String, Object> tokenResponse = objectMapper.readValue(response.getBody(), Map.class);
+            return (String) tokenResponse.get("access_token");
+        } catch (Exception e) {
+            throw new RuntimeException("카카오 토큰 파싱 실패", e);
+        }
+    }
+
+    public Map<String, Object> getUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+        ResponseEntity<String> response = restTemplate.exchange("https://kapi.kakao.com/v2/user/me", HttpMethod.GET, entity, String.class);
+
+        try {
+            return objectMapper.readValue(response.getBody(), Map.class);
+        } catch (Exception e) {
+            throw new RuntimeException("카카오 사용자 정보 파싱 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/gongspot/project/global/auth/service/TokenService.java
+++ b/src/main/java/com/gongspot/project/global/auth/service/TokenService.java
@@ -74,4 +74,9 @@ public class TokenService {
         refreshTokenRepository.deleteByUserId(userId);
     }
 
+    public TokenPair generateTokensFromKakaoUserInfo(String email, String nickname, String profileImg) {
+        User user = userService.findOrCreateUser(email, nickname, profileImg);
+        return generateAndSaveTokens(user);
+    }
+
 }

--- a/src/main/java/com/gongspot/project/global/config/AppConfig.java
+++ b/src/main/java/com/gongspot/project/global/config/AppConfig.java
@@ -1,0 +1,13 @@
+package com.gongspot.project.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/gongspot/project/global/config/SecurityConfig.java
+++ b/src/main/java/com/gongspot/project/global/config/SecurityConfig.java
@@ -29,7 +29,8 @@ public class SecurityConfig {
             "/api/v1/replies/**",
             "/auth/login",
             "/auth/login/kakao/**",
-            "/auth/logout"
+            "/auth/logout",
+            "/auth/oauth/kakao/**"
     };
 
     @Bean

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,7 +30,7 @@ logging.level.org.springframework.security=DEBUG
 # OAuth2 registration ??
 spring.security.oauth2.client.registration.kakao.client-id=${OAUTH_RESTAPI_KEY}
 spring.security.oauth2.client.registration.kakao.client-secret=none
-spring.security.oauth2.client.registration.kakao.redirect-uri=http://localhost:8080/auth/oauth/kakao/callback
+spring.security.oauth2.client.registration.kakao.redirect-uri=http://localhost:5182/oauth/kakao/callback
 # TODO: main ?????? ??? ?????? ? !!!
 
 spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,7 +30,8 @@ logging.level.org.springframework.security=DEBUG
 # OAuth2 registration ??
 spring.security.oauth2.client.registration.kakao.client-id=${OAUTH_RESTAPI_KEY}
 spring.security.oauth2.client.registration.kakao.client-secret=none
-spring.security.oauth2.client.registration.kakao.redirect-uri={baseUrl}/login/oauth2/code/{registrationId}
+spring.security.oauth2.client.registration.kakao.redirect-uri=http://localhost:8080/auth/oauth/kakao/callback
+# TODO: main ?????? ??? ?????? ? !!!
 
 spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
 spring.security.oauth2.client.registration.kakao.client-authentication-method=client_secret_post


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- Refactor/69

## ⚡️ 작업동기

- 프론트에서 카카오 인가 코드를 받아 백엔드로 전달하는 방식으로 OAuth2 로그인 흐름을 변경하기 위해 작업을 진행했습니다.
- 무한 리다이렉션 문제를 해결하고, 프론트-백 간 역할 분리를 명확히 하기 위함입니다.

## 🔑 주요 변경사항

- 카카오 인가 코드를 파라미터로 받아 로그인 처리하는 /auth/oauth/kakao/callback API 추가

## 💡 관련 이슈

- #69 

## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!
