### PR TITLE
[FEAT] 이벤트 배너 조회, 상세 조회 API 

### DIFF
--- a/src/main/java/com/gongspot/project/domain/banner/controller/BannerController.java
+++ b/src/main/java/com/gongspot/project/domain/banner/controller/BannerController.java
@@ -1,0 +1,30 @@
+package com.gongspot.project.domain.banner.controller;
+
+import com.gongspot.project.common.response.ApiResponse;
+import com.gongspot.project.domain.banner.converter.BannerConverter;
+import com.gongspot.project.domain.banner.dto.BannerResponseDTO;
+import com.gongspot.project.domain.banner.service.BannerQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/banners")
+@Tag(name = "이벤트 배너", description = "이벤트 배너 관련 API")
+public class BannerController {
+
+    private final BannerQueryService bannerQueryService;
+
+    @GetMapping()
+    @Operation(summary = "이벤트 배너 조회", description = "이벤트 배너를 조회합니다.")
+    public ApiResponse<BannerResponseDTO.GetBannerListDTO> getBannerList() {
+        List<BannerResponseDTO.GetBannerDTO> bannerList = bannerQueryService.getBanner();
+        return ApiResponse.onSuccess(BannerConverter.toBannerListDTO(bannerList));
+    }
+}

--- a/src/main/java/com/gongspot/project/domain/banner/controller/BannerController.java
+++ b/src/main/java/com/gongspot/project/domain/banner/controller/BannerController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,5 +27,14 @@ public class BannerController {
     public ApiResponse<BannerResponseDTO.GetBannerListDTO> getBannerList() {
         List<BannerResponseDTO.GetBannerDTO> bannerList = bannerQueryService.getBanner();
         return ApiResponse.onSuccess(BannerConverter.toBannerListDTO(bannerList));
+    }
+
+    @GetMapping("/{banners_id}")
+    @Operation(summary = "이벤트 배너 상세 조회", description = "이벤트 배너를 상세 조회합니다.")
+    public ApiResponse<BannerResponseDTO.GetBannerDetailDTO> getBannerDetailList(
+            @PathVariable("banners_id") Long banners_id
+    ) {
+        BannerResponseDTO.GetBannerDetailDTO bannerDetail = bannerQueryService.getBannerDetail(banners_id);
+        return ApiResponse.onSuccess(bannerDetail);
     }
 }

--- a/src/main/java/com/gongspot/project/domain/banner/converter/BannerConverter.java
+++ b/src/main/java/com/gongspot/project/domain/banner/converter/BannerConverter.java
@@ -1,0 +1,14 @@
+package com.gongspot.project.domain.banner.converter;
+
+import com.gongspot.project.domain.banner.dto.BannerResponseDTO;
+import com.gongspot.project.domain.home.dto.HomeResponseDTO;
+
+import java.util.List;
+
+public class BannerConverter {
+    public static BannerResponseDTO.GetBannerListDTO toBannerListDTO(List<BannerResponseDTO.GetBannerDTO> banner) {
+        return BannerResponseDTO.GetBannerListDTO.builder()
+                .bannerList(banner)
+                .build();
+    }
+}

--- a/src/main/java/com/gongspot/project/domain/banner/dto/BannerResponseDTO.java
+++ b/src/main/java/com/gongspot/project/domain/banner/dto/BannerResponseDTO.java
@@ -22,4 +22,14 @@ public class BannerResponseDTO {
     public static class GetBannerListDTO {
         List<GetBannerDTO> bannerList;
     }
+
+    @Getter
+    @AllArgsConstructor
+    public static class GetBannerDetailDTO {
+        Long BannerId;
+        String title;
+        String content;
+        String imageUrl;
+        String datetime;
+    }
 }

--- a/src/main/java/com/gongspot/project/domain/banner/dto/BannerResponseDTO.java
+++ b/src/main/java/com/gongspot/project/domain/banner/dto/BannerResponseDTO.java
@@ -1,0 +1,25 @@
+package com.gongspot.project.domain.banner.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class BannerResponseDTO {
+    @Getter
+    @AllArgsConstructor
+    public static class GetBannerDTO {
+        Long BannerId;
+        String imageUrl;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetBannerListDTO {
+        List<GetBannerDTO> bannerList;
+    }
+}

--- a/src/main/java/com/gongspot/project/domain/banner/repository/BannerRepository.java
+++ b/src/main/java/com/gongspot/project/domain/banner/repository/BannerRepository.java
@@ -1,0 +1,7 @@
+package com.gongspot.project.domain.banner.repository;
+
+import com.gongspot.project.domain.banner.entity.Banner;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BannerRepository extends JpaRepository<Banner, Long>, BannerRepositoryCustom {
+}

--- a/src/main/java/com/gongspot/project/domain/banner/repository/BannerRepositoryCustom.java
+++ b/src/main/java/com/gongspot/project/domain/banner/repository/BannerRepositoryCustom.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface BannerRepositoryCustom {
     List<BannerResponseDTO.GetBannerDTO> findBanner();
+    BannerResponseDTO.GetBannerDetailDTO findBannerDetailById(Long bannerId);
 }

--- a/src/main/java/com/gongspot/project/domain/banner/repository/BannerRepositoryCustom.java
+++ b/src/main/java/com/gongspot/project/domain/banner/repository/BannerRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.gongspot.project.domain.banner.repository;
+
+import com.gongspot.project.domain.banner.dto.BannerResponseDTO;
+
+import java.util.List;
+
+public interface BannerRepositoryCustom {
+    List<BannerResponseDTO.GetBannerDTO> findBanner();
+}

--- a/src/main/java/com/gongspot/project/domain/banner/repository/BannerRepositoryImpl.java
+++ b/src/main/java/com/gongspot/project/domain/banner/repository/BannerRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.gongspot.project.domain.banner.repository;
+
+import com.gongspot.project.domain.banner.dto.BannerResponseDTO;
+import com.gongspot.project.domain.banner.entity.QBanner;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class BannerRepositoryImpl implements BannerRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    QBanner banner = QBanner.banner;
+
+    @Override
+    public List<BannerResponseDTO.GetBannerDTO> findBanner() {
+        return queryFactory
+                .select(Projections.constructor(BannerResponseDTO.GetBannerDTO.class,
+                        banner.id,
+                        banner.imgUrl
+                ))
+                .from(banner)
+                .fetch();
+    }
+}

--- a/src/main/java/com/gongspot/project/domain/banner/repository/BannerRepositoryImpl.java
+++ b/src/main/java/com/gongspot/project/domain/banner/repository/BannerRepositoryImpl.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
+import static com.querydsl.core.types.dsl.Expressions.stringTemplate;
+
 @RequiredArgsConstructor
 public class BannerRepositoryImpl implements BannerRepositoryCustom {
     private final JPAQueryFactory queryFactory;
@@ -23,5 +25,21 @@ public class BannerRepositoryImpl implements BannerRepositoryCustom {
                 ))
                 .from(banner)
                 .fetch();
+    }
+
+    @Override
+    public BannerResponseDTO.GetBannerDetailDTO findBannerDetailById(Long bannerId) {
+        return queryFactory
+                .select(Projections.constructor(
+                        BannerResponseDTO.GetBannerDetailDTO.class,
+                        banner.id,
+                        banner.title,
+                        banner.content,
+                        banner.imgUrl,
+                        stringTemplate("DATE_FORMAT({0}, '%Y.%m.%d')", banner.createdAt)
+                ))
+                .from(banner)
+                .where(banner.id.eq(bannerId))
+                .fetchOne();
     }
 }

--- a/src/main/java/com/gongspot/project/domain/banner/service/BannerQueryService.java
+++ b/src/main/java/com/gongspot/project/domain/banner/service/BannerQueryService.java
@@ -1,0 +1,9 @@
+package com.gongspot.project.domain.banner.service;
+
+import com.gongspot.project.domain.banner.dto.BannerResponseDTO;
+
+import java.util.List;
+
+public interface BannerQueryService {
+    List<BannerResponseDTO.GetBannerDTO> getBanner();
+}

--- a/src/main/java/com/gongspot/project/domain/banner/service/BannerQueryService.java
+++ b/src/main/java/com/gongspot/project/domain/banner/service/BannerQueryService.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface BannerQueryService {
     List<BannerResponseDTO.GetBannerDTO> getBanner();
+    BannerResponseDTO.GetBannerDetailDTO getBannerDetail(Long bannerId);
 }

--- a/src/main/java/com/gongspot/project/domain/banner/service/BannerQueryServiceImpl.java
+++ b/src/main/java/com/gongspot/project/domain/banner/service/BannerQueryServiceImpl.java
@@ -15,4 +15,9 @@ public class BannerQueryServiceImpl implements BannerQueryService {
     public List<BannerResponseDTO.GetBannerDTO> getBanner() {
         return bannerRepository.findBanner();
     }
+
+    @Override
+    public BannerResponseDTO.GetBannerDetailDTO getBannerDetail(Long bannerId) {
+        return bannerRepository.findBannerDetailById(bannerId);
+    }
 }

--- a/src/main/java/com/gongspot/project/domain/banner/service/BannerQueryServiceImpl.java
+++ b/src/main/java/com/gongspot/project/domain/banner/service/BannerQueryServiceImpl.java
@@ -1,0 +1,18 @@
+package com.gongspot.project.domain.banner.service;
+
+import com.gongspot.project.domain.banner.dto.BannerResponseDTO;
+import com.gongspot.project.domain.banner.repository.BannerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BannerQueryServiceImpl implements BannerQueryService {
+    private final BannerRepository bannerRepository;
+    @Override
+    public List<BannerResponseDTO.GetBannerDTO> getBanner() {
+        return bannerRepository.findBanner();
+    }
+}


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- feature/76

## ⚡️ 작업동기

- 이벤트 배너 조회, 상세 조회 API 구현

## 🔑 주요 변경사항

- 

## 💡 관련 이슈

- 이벤트 배너 조회
<img width="1390" height="368" alt="image" src="https://github.com/user-attachments/assets/bb1f32eb-3ccf-4f81-b790-63fb9eb35c56" />

- 이벤트 배너 상세 조회
<img width="1389" height="380" alt="image" src="https://github.com/user-attachments/assets/127c0a12-66a2-44d6-b6e4-bec9402ad89b" />

## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!
