### PR TITLE
[FEAT] 공지사항 삭제, 배너 수정,삭제 api 구현 , closes #87

### DIFF
--- a/src/main/java/com/gongspot/project/domain/banner/controller/BannerController.java
+++ b/src/main/java/com/gongspot/project/domain/banner/controller/BannerController.java
@@ -75,4 +75,15 @@ public class BannerController {
         bannerCommandService.updateBanner(bannerId, requestDTO, thumbnailFile, mediaIdsToDelete, attachments);
         return ApiResponse.onSuccess();
     }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "배너 삭제 (관리자)")
+    @DeleteMapping("/{bannerId}")
+    public ApiResponse<String> deleteBanner(
+            @Parameter(description = "삭제할 배너 ID")
+            @PathVariable("bannerId") Long bannerId
+    ) {
+        bannerCommandService.deleteBanner(bannerId);
+        return ApiResponse.onSuccess();
+    }
 }

--- a/src/main/java/com/gongspot/project/domain/banner/controller/BannerController.java
+++ b/src/main/java/com/gongspot/project/domain/banner/controller/BannerController.java
@@ -2,15 +2,22 @@ package com.gongspot.project.domain.banner.controller;
 
 import com.gongspot.project.common.response.ApiResponse;
 import com.gongspot.project.domain.banner.converter.BannerConverter;
+import com.gongspot.project.domain.banner.dto.BannerRequestDTO;
 import com.gongspot.project.domain.banner.dto.BannerResponseDTO;
+import com.gongspot.project.domain.banner.service.BannerCommandService;
 import com.gongspot.project.domain.banner.service.BannerQueryService;
+import com.gongspot.project.domain.notification.dto.NotificationRequestDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -21,6 +28,7 @@ import java.util.List;
 public class BannerController {
 
     private final BannerQueryService bannerQueryService;
+    private final BannerCommandService bannerCommandService;
 
     @GetMapping()
     @Operation(summary = "이벤트 배너 조회", description = "이벤트 배너를 조회합니다.")
@@ -36,5 +44,35 @@ public class BannerController {
     ) {
         BannerResponseDTO.GetBannerDetailDTO bannerDetail = bannerQueryService.getBannerDetail(bannerId);
         return ApiResponse.onSuccess(bannerDetail);
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "배너 수정 (관리자)")
+    @PatchMapping(value = "/{bannerId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<String> updateBanner(
+            @Parameter(description = "배너 ID")
+            @PathVariable("bannerId") Long bannerId,
+
+            @Parameter(
+                    description = "수정할 본문 내용(JSON)",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = BannerRequestDTO.class)
+                    )
+            )
+            @Valid @RequestPart("request") BannerRequestDTO requestDTO,
+
+            @Parameter(description = "썸네일 이미지 파일 (선택사항)")
+            @RequestPart(value = "thumbnailFile", required = false) MultipartFile thumbnailFile,
+
+            @Parameter(description = "삭제할 첨부파일 ID 리스트 (선택)")
+            @RequestPart(value = "attachmentIdsToDelete", required = false) List<Long> mediaIdsToDelete,
+
+            @Parameter(description = "새로 추가할 첨부파일들 (선택)")
+            @RequestPart(value = "attachments", required = false) List<MultipartFile> attachments
+    ) {
+        if (attachments == null) attachments = List.of();
+        bannerCommandService.updateBanner(bannerId, requestDTO, thumbnailFile, mediaIdsToDelete, attachments);
+        return ApiResponse.onSuccess();
     }
 }

--- a/src/main/java/com/gongspot/project/domain/banner/converter/BannerConverter.java
+++ b/src/main/java/com/gongspot/project/domain/banner/converter/BannerConverter.java
@@ -1,5 +1,6 @@
 package com.gongspot.project.domain.banner.converter;
 
+import com.gongspot.project.domain.banner.dto.BannerRequestDTO;
 import com.gongspot.project.domain.banner.dto.BannerResponseDTO;
 import com.gongspot.project.domain.banner.entity.Banner;
 import com.gongspot.project.domain.media.entity.Media;
@@ -53,5 +54,10 @@ public class BannerConverter {
                 thumbnailUrl,
                 attachmentDTOs
         );
+    }
+
+    public static void updateBannerEntity(Banner banner, BannerRequestDTO requestDTO) {
+        banner.setTitle(requestDTO.getTitle());
+        banner.setContent(requestDTO.getContent());
     }
 }

--- a/src/main/java/com/gongspot/project/domain/banner/dto/BannerRequestDTO.java
+++ b/src/main/java/com/gongspot/project/domain/banner/dto/BannerRequestDTO.java
@@ -1,0 +1,16 @@
+package com.gongspot.project.domain.banner.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BannerRequestDTO {
+    @NotBlank(message = "제목은 필수 입력 항목입니다.")
+    private String title;
+
+    private String content;
+}

--- a/src/main/java/com/gongspot/project/domain/banner/service/BannerCommandService.java
+++ b/src/main/java/com/gongspot/project/domain/banner/service/BannerCommandService.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface BannerCommandService {
     void updateBanner(Long bannerId, BannerRequestDTO bannerRequestDTO, MultipartFile thumbnailFile, List<Long> mediaIdsToDelete, List<MultipartFile> attachments);
+    void deleteBanner(Long bannerId);
 }

--- a/src/main/java/com/gongspot/project/domain/banner/service/BannerCommandService.java
+++ b/src/main/java/com/gongspot/project/domain/banner/service/BannerCommandService.java
@@ -1,0 +1,10 @@
+package com.gongspot.project.domain.banner.service;
+
+import com.gongspot.project.domain.banner.dto.BannerRequestDTO;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public interface BannerCommandService {
+    void updateBanner(Long bannerId, BannerRequestDTO bannerRequestDTO, MultipartFile thumbnailFile, List<Long> mediaIdsToDelete, List<MultipartFile> attachments);
+}

--- a/src/main/java/com/gongspot/project/domain/banner/service/BannerCommandServiceImpl.java
+++ b/src/main/java/com/gongspot/project/domain/banner/service/BannerCommandServiceImpl.java
@@ -1,0 +1,96 @@
+package com.gongspot.project.domain.banner.service;
+
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.gongspot.project.common.code.status.ErrorStatus;
+import com.gongspot.project.common.exception.BusinessException;
+import com.gongspot.project.domain.banner.converter.BannerConverter;
+import com.gongspot.project.domain.banner.dto.BannerRequestDTO;
+import com.gongspot.project.domain.banner.entity.Banner;
+import com.gongspot.project.domain.banner.repository.BannerRepository;
+import com.gongspot.project.domain.media.entity.Media;
+import com.gongspot.project.domain.media.repository.MediaRepository;
+import com.gongspot.project.domain.uuid.repository.UuidRepository;
+import com.gongspot.project.domain.uuid.entity.Uuid;
+import com.gongspot.project.global.aws.s3.AmazonS3Manager;
+import com.gongspot.project.global.config.AmazonConfig;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class BannerCommandServiceImpl implements BannerCommandService {
+    private final BannerRepository bannerRepository;
+    private final MediaRepository mediaRepository;
+    private final AmazonS3Manager s3Manager;
+    private final UuidRepository uuidRepository;
+    private final AmazonConfig amazonConfig;
+
+    @Override
+    @Transactional
+    public void updateBanner(Long bannerId, BannerRequestDTO bannerRequestDTO, MultipartFile thumbnailFile, List<Long> mediaIdsToDelete, List<MultipartFile> attachments) {
+        Banner banner = bannerRepository.findById(bannerId)
+                .orElseThrow(() -> new BusinessException(ErrorStatus.BANNER_NOT_FOUND));
+
+        BannerConverter.updateBannerEntity(banner, bannerRequestDTO);
+        bannerRepository.save(banner);
+
+        if (thumbnailFile != null && !thumbnailFile.isEmpty()) {
+            mediaRepository.findByBannerAndIsThumbnail(banner, true).ifPresent(media -> {
+                String keyName = media.getUrl().substring(media.getUrl().lastIndexOf("/") + 1);
+                s3Manager.deleteFile(amazonConfig.getNotificationBucket(), keyName);
+                mediaRepository.delete(media);
+            });
+            String url = uploadToS3(thumbnailFile);
+            Media thumbnailMedia = createMedia(url, thumbnailFile.getOriginalFilename(),
+                    thumbnailFile.getContentType(), true);
+            thumbnailMedia.setBanner(banner);
+            mediaRepository.save(thumbnailMedia);
+        }
+        if (mediaIdsToDelete != null && !mediaIdsToDelete.isEmpty()) {
+            List<Media> mediaToDelete = mediaRepository.findAllById(mediaIdsToDelete);
+
+            for (Media media : mediaToDelete) {
+                if (media.getBanner() != null && media.getBanner().getId().equals(bannerId)) {
+                    String keyName = media.getUrl().substring(media.getUrl().lastIndexOf("/") + 1);
+                    s3Manager.deleteFile(amazonConfig.getNotificationBucket(), keyName);
+                    mediaRepository.delete(media);
+                }
+            }
+        }
+
+        if (attachments != null) {
+            for (MultipartFile file : attachments) {
+                if (file == null || file.isEmpty()) continue;
+
+                String url = uploadToS3(file);
+                Media media = createMedia(url, file.getOriginalFilename(), file.getContentType(), false);
+                media.setBanner(banner);
+                mediaRepository.save(media);
+            }
+        }
+
+    }
+    private String uploadToS3(MultipartFile file) {
+        String uuidStr = UUID.randomUUID().toString();
+        Uuid savedUuid = uuidRepository.save(Uuid.builder().uuid(uuidStr).build());
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(file.getSize());
+        metadata.setContentType(file.getContentType());
+
+        return s3Manager.uploadFile(amazonConfig.getNotificationBucket(), savedUuid.getUuid(), file, metadata);
+    }
+
+    private Media createMedia(String url, String originalFileName, String contentType, boolean isThumbnail) {
+        Media media = new Media();
+        media.setUrl(url);
+        media.setOriginalFileName(originalFileName);
+        media.setContentType(contentType);
+        media.setIsThumbnail(isThumbnail);
+        return media;
+    }
+}

--- a/src/main/java/com/gongspot/project/domain/media/entity/Media.java
+++ b/src/main/java/com/gongspot/project/domain/media/entity/Media.java
@@ -45,5 +45,5 @@ public class Media extends BaseEntity {
     private String contentType;
 
     @Column(nullable = false)
-    private Boolean isThumbnail = false;;
+    private Boolean isThumbnail = false;
 }

--- a/src/main/java/com/gongspot/project/domain/media/repository/MediaRepository.java
+++ b/src/main/java/com/gongspot/project/domain/media/repository/MediaRepository.java
@@ -1,5 +1,6 @@
 package com.gongspot.project.domain.media.repository;
 
+import com.gongspot.project.domain.banner.entity.Banner;
 import com.gongspot.project.domain.media.entity.Media;
 import com.gongspot.project.domain.review.entity.Review;
 import com.gongspot.project.domain.place.entity.Place;
@@ -19,4 +20,5 @@ public interface MediaRepository extends JpaRepository<Media, Long> {
     List<Media> findByBannerId(Long bannerId);
     Optional<Media> findByBannerIdAndIsThumbnailTrue(Long bannerId);
     List<Media> findByBannerIdAndIsThumbnailFalse(Long bannerId);
+    Optional<Media> findByBannerAndIsThumbnail(Banner banner, Boolean isThumbnail);
 }

--- a/src/main/java/com/gongspot/project/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/gongspot/project/domain/notification/controller/NotificationController.java
@@ -106,4 +106,15 @@ public class NotificationController {
         notificationCommandService.updateNotification(notificationId, requestDTO, mediaIdsToDelete, attachments);
         return ApiResponse.onSuccess();
     }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "공지사항 삭제 (관리자)")
+    @DeleteMapping("/{notificationId}")
+    public ApiResponse<String> deleteNotification(
+            @Parameter(description = "삭제할 공지사항 ID")
+            @PathVariable("notificationId") Long notificationId
+    ) {
+        notificationCommandService.deleteNotification(notificationId);
+        return ApiResponse.onSuccess();
+    }
 }

--- a/src/main/java/com/gongspot/project/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/com/gongspot/project/domain/notification/converter/NotificationConverter.java
@@ -65,10 +65,6 @@ public class NotificationConverter {
         notification.setContent(requestDTO.getContent());
     }
 
-    public static void updateBannerEntity(Banner banner, NotificationRequestDTO requestDTO) {
-        banner.setTitle(requestDTO.getTitle());
-        banner.setContent(requestDTO.getContent());
-    }
 
     public static NotificationResponseDTO.NotificationBannerItemDTO toNotificationBannerItem(Notification notification) {
         String formattedDate = notification.getDate().format(DateTimeFormatter.ofPattern("yy.MM.dd"));

--- a/src/main/java/com/gongspot/project/domain/notification/entity/Notification.java
+++ b/src/main/java/com/gongspot/project/domain/notification/entity/Notification.java
@@ -15,7 +15,7 @@ import java.util.List;
 @AllArgsConstructor
 @Setter
 @Entity
-@Table(name = "Notification")
+@Table(name = "Notifications")
 public class Notification extends BaseEntity {
     // 공지사항 엔티티
 

--- a/src/main/java/com/gongspot/project/domain/notification/service/NotificationCommandService.java
+++ b/src/main/java/com/gongspot/project/domain/notification/service/NotificationCommandService.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface NotificationCommandService {
     void createNotification(String category, NotificationRequestDTO requestDTO, List<MultipartFile> attachments ,MultipartFile thumbnailFile);
     void updateNotification(Long notificationId, NotificationRequestDTO requestDTO, List<Long> mediaIdsToDelete,List<MultipartFile> attachments);
+    void deleteNotification(Long notificationId);
 }


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- feature/87

## ⚡️ 작업동기

- 관리자가 공지사항을 삭제 , 배너 수정, 삭제하는 api 입니다 

## 🔑 주요 변경사항

- PATCH notifications/{notificationId}
- DELETE notifications/{notificationId}
- DELETE banners/{bannerId}

## 💡 관련 이슈

- #87 
<img width="1586" height="566" alt="image" src="https://github.com/user-attachments/assets/c701b176-3f14-46af-af8b-7ae75acbb175" />
<img width="1869" height="1016" alt="image" src="https://github.com/user-attachments/assets/beb8ee34-48c3-41e8-837d-49b84bc88b26" />


