### PR TITLE
[FIX] notification 제약조건 에러 해결

### DIFF
--- a/src/main/java/com/gongspot/project/domain/notification/entity/Notification.java
+++ b/src/main/java/com/gongspot/project/domain/notification/entity/Notification.java
@@ -21,7 +21,7 @@ public class Notification extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "noti_id")
+    @Column(name = "notification_id")
     private Long id;
 
     @Column(name = "date")


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- fix/108

## ⚡️ 작업동기

- medias테이블이랑 notifications테이블의 외래 키가 서로 맞지 않아서 수정했습니다 