### PR TITLE
♻️ Refactor: 로그인시 신규회원 및 관리자 표시되도록 수정, closes #110

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,5 +121,5 @@ jobs:
           script: |
             export $(cat /home/ubuntu/gongspot/.env | xargs)
             sudo fuser -k -n tcp 8080 || true
-            nohup java -jar /home/ubuntu/gongspot/build/libs/*SNAPSHOT.jar > /home/ubuntu/gongspot/app.log 2>&1 &
+            nohup java -jar -Dspring.profiles.active=prod /home/ubuntu/gongspot/build/libs/*SNAPSHOT.jar > /home/ubuntu/gongspot/app.log 2>&1 &
             tail -n 50 /home/ubuntu/gongspot/app.log

--- a/src/main/java/com/gongspot/project/domain/user/entity/User.java
+++ b/src/main/java/com/gongspot/project/domain/user/entity/User.java
@@ -6,12 +6,10 @@ import com.gongspot.project.common.enums.LocationEnum;
 import com.gongspot.project.common.enums.PlaceEnum;
 import com.gongspot.project.common.enums.PurposeEnum;
 import com.gongspot.project.common.enums.RoleEnum;
-import com.gongspot.project.domain.place.entity.Place;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -93,6 +91,10 @@ public class User extends BaseEntity {
 
     public void updatePreferPlace(List<PlaceEnum> places) {
         this.preferPlace = places;
+    }
+
+    public Long getId() {
+        return id;
     }
 
 }

--- a/src/main/java/com/gongspot/project/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/gongspot/project/domain/user/repository/UserRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByEmail(String email);
     boolean existsByNickname(String nickname);
     Optional<User> findByEmailAndDeletedAtIsNull(String email);
 }

--- a/src/main/java/com/gongspot/project/domain/user/service/UserService.java
+++ b/src/main/java/com/gongspot/project/domain/user/service/UserService.java
@@ -25,11 +25,6 @@ public class UserService {
         this.userRepository = userRepository;
     }
 
-    public User findByEmail(String email) {
-        return userRepository.findByEmail(email)
-                .orElse(null);
-    }
-
     public User findById(Long id) {
         return userRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorStatus.MEMBER_NOT_FOUND));
@@ -46,9 +41,19 @@ public class UserService {
         return userRepository.save(user);
     }
 
-    public User findOrCreateUser(String email, String nickname, String profileImageUrl) {
+    public record UserCreationResult(User user, boolean isNewUser) {}
+
+    public UserCreationResult findOrCreateUser(String email, String nickname, String profileImageUrl) {
         Optional<User> existing = userRepository.findByEmailAndDeletedAtIsNull(email);
-        return existing.orElseGet(() -> createUser(email, nickname, profileImageUrl));
+
+        if (existing.isPresent()) {
+            return new UserCreationResult(existing.get(), false);
+        }
+
+        else {
+            User newUser = createUser(email, nickname, profileImageUrl);
+            return new UserCreationResult(newUser, true);
+        }
     }
 
     public void setPreferences(User user, UserRequestDTO.PreferRequestDTO prefDTO) {

--- a/src/main/java/com/gongspot/project/global/auth/dto/TokenResponseDTO.java
+++ b/src/main/java/com/gongspot/project/global/auth/dto/TokenResponseDTO.java
@@ -1,12 +1,34 @@
 package com.gongspot.project.global.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class TokenResponseDTO {
+    private final Long userId;
+    private final boolean isAdmin;
+    private final boolean isNewUser;
     private final String accessToken;
     private final String refreshToken;
 
-    public TokenResponseDTO(String accessToken, String refreshToken) {
+    public TokenResponseDTO(Long userId, boolean isAdmin, boolean isNewUser, String accessToken, String refreshToken) {
+        this.userId = userId;
+        this.isAdmin = isAdmin;
+        this.isNewUser = isNewUser;
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    @JsonProperty("isAdmin")
+    public boolean isAdmin() {
+        return isAdmin;
+    }
+
+    @JsonProperty("isNewUser")
+    public boolean isNewUser() {
+        return isNewUser;
     }
 
     public String getAccessToken() {

--- a/src/main/java/com/gongspot/project/global/auth/oauth/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/gongspot/project/global/auth/oauth/CustomOAuth2SuccessHandler.java
@@ -45,13 +45,11 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
             }
         }
 
-        // email 없으면 다른 식별자로 처리 (예: id)
-        User user = userService.findByEmail(email);
-        if (user == null) {
-            user = userService.createUser(email, nickname, profileImage);
-        }
+        UserService.UserCreationResult userResult = userService.findOrCreateUser(email, nickname, profileImage);
+        User user = userResult.user();
+        boolean isNewUser = userResult.isNewUser();
 
-        TokenService.TokenPair tokenPair = tokenService.generateAndSaveTokens(user);
+        TokenService.TokenPair tokenPair = tokenService.generateAndSaveTokens(user, isNewUser);
         String accessToken = tokenPair.accessToken();
         String refreshToken = tokenPair.refreshToken();
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 spring.application.name=project
+spring.profiles.active=local
 
 #spring.datasource.url=jdbc:mysql://localhost:3306/${DB_NAME}
 spring.datasource.url=${DB_URL}


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- refactor/110

## ⚡️ 작업동기

- 카카오 소셜 로그인 기능 개선: API 응답 형식과 데이터 처리 로직을 수정하여 클라이언트 요구사항에 맞게 변경하고, 데이터 무결성 문제를 해결하기 위함
- 배포 환경 설정 자동화: 로컬과 배포 환경 간의 설정 파일(properties) 수동 변경 없이, 프로필(profile)을 이용해 자동으로 환경에 맞게 설정되도록 스크립트를 개선하기 위함

## 🔑 주요 변경사항

- TokenResponseDTO 수정: userId, isAdmin, isNewUser 필드가 JSON 응답에 포함되도록 DTO에 누락되었던 getter 메서드를 추가했습니다. && JSON 필드 이름을 admin과 newUser 대신 isAdmin과 isNewUser로 보이도록 @JsonProperty 어노테이션을 추가했습니다.
- 데이터베이스 문제 해결: findByEmail 쿼리가 중복된 이메일 계정을 반환하는 IncorrectResultSizeDataAccessException 오류를 해결했습니다. 
- 배포 스크립트 수정: 배포 시 prod 프로필을 활성화하도록 java -jar 명령어에 -Dspring.profiles.active=prod 옵션을 추가했습니다. (application.properties 파일에 있는 spring.profiles.active=local 설정보다 배포 시 프로필 설정이 우선 적용되도록 변경)

## 💡 관련 이슈

- #110

## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!
