### PR TITLE
[REFACTOR] 썸네일 파일 이름 반환, close #115

### DIFF
--- a/src/main/java/com/gongspot/project/domain/banner/converter/BannerConverter.java
+++ b/src/main/java/com/gongspot/project/domain/banner/converter/BannerConverter.java
@@ -32,9 +32,14 @@ public class BannerConverter {
 
     public static BannerResponseDTO.GetBannerDetailDTO toBannerDetailDTO(Banner banner, Optional<Media> thumbnailMediaOptional, List<Media> attachments) {
 
-        String thumbnailUrl = null;
+        BannerResponseDTO.thumbnailDTO thumbnail = null;
         if (thumbnailMediaOptional.isPresent()) {
-            thumbnailUrl = thumbnailMediaOptional.get().getUrl();
+            Media thumbnailMedia = thumbnailMediaOptional.get();
+            thumbnail = BannerResponseDTO.thumbnailDTO.builder()
+                    .thumbnailId(thumbnailMedia.getId())
+                    .url(thumbnailMedia.getUrl())
+                    .fileName(thumbnailMedia.getOriginalFileName())
+                    .build();
         }
 
         List<BannerResponseDTO.AttachmentDTO> attachmentDTOs = attachments.stream()
@@ -51,7 +56,7 @@ public class BannerConverter {
                 banner.getTitle(),
                 banner.getContent(),
                 banner.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")),
-                thumbnailUrl,
+                thumbnail,
                 attachmentDTOs
         );
     }

--- a/src/main/java/com/gongspot/project/domain/banner/dto/BannerResponseDTO.java
+++ b/src/main/java/com/gongspot/project/domain/banner/dto/BannerResponseDTO.java
@@ -1,5 +1,6 @@
 package com.gongspot.project.domain.banner.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,7 +32,7 @@ public class BannerResponseDTO {
         String title;
         String content;
         String datetime;
-        String thumbnailUrl;
+        thumbnailDTO thumbnail;
         List<AttachmentDTO> attachments;
     }
 
@@ -41,6 +42,16 @@ public class BannerResponseDTO {
     @Builder
     public static class AttachmentDTO {
         private Long attachmentId;
+        private String url;
+        private String fileName;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class thumbnailDTO {
+        private Long thumbnailId;
         private String url;
         private String fileName;
     }

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,3 +1,0 @@
-spring.config.activate.on-profile=local
-
-spring.security.oauth2.client.registration.kakao.redirect-uri=http://localhost:5182/oauth/kakao/callback


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- refactor/115

## ⚡️ 작업동기

- 배너 썸네일 파일 url -> id, 이름, url 반환으로 수정 

## 🔑 주요 변경사항

-  GET banner/{bannerId}

<img width="840" height="369" alt="image" src="https://github.com/user-attachments/assets/5502b431-a807-4988-8039-3b87990219a9" />

