### PR TITLE
[FEAT] 리뷰삭제하는 API 설계 , 장소 리뷰목록 조회 수정, closes #129

### DIFF
--- a/src/main/generated/com/gongspot/project/domain/review/entity/QReview.java
+++ b/src/main/generated/com/gongspot/project/domain/review/entity/QReview.java
@@ -40,6 +40,8 @@ public class QReview extends EntityPathBase<Review> {
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
+    public final BooleanPath isDeleted = createBoolean("isDeleted");
+
     public final ListPath<com.gongspot.project.domain.media.entity.Media, com.gongspot.project.domain.media.entity.QMedia> mediaList = this.<com.gongspot.project.domain.media.entity.Media, com.gongspot.project.domain.media.entity.QMedia>createList("mediaList", com.gongspot.project.domain.media.entity.Media.class, com.gongspot.project.domain.media.entity.QMedia.class, PathInits.DIRECT2);
 
     public final ListPath<com.gongspot.project.common.enums.MoodEnum, EnumPath<com.gongspot.project.common.enums.MoodEnum>> mood = this.<com.gongspot.project.common.enums.MoodEnum, EnumPath<com.gongspot.project.common.enums.MoodEnum>>createList("mood", com.gongspot.project.common.enums.MoodEnum.class, EnumPath.class, PathInits.DIRECT2);

--- a/src/main/java/com/gongspot/project/common/code/status/ErrorStatus.java
+++ b/src/main/java/com/gongspot/project/common/code/status/ErrorStatus.java
@@ -52,6 +52,7 @@ public enum ErrorStatus implements BaseErrorCode {
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW4001", "리뷰를 찾을 수 없습니다."),
     REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "REVIEW4002", "이미 해당 장소에 리뷰를 작성했습니다."),
     REVIEW_SAVE_FAIL(HttpStatus.BAD_REQUEST, "REVIEW4003", "리뷰 저장에 실패했습니다."),
+    UNAUTHORIZED_REVIEW_DELETION(HttpStatus.UNAUTHORIZED, "REVIEW4004", "본인의 리뷰만 삭제할 수 있습니다."),
 
     // Media Error
     MEDIA_NOT_FOUND(HttpStatus.NOT_FOUND, "MEDIA4001", "미디어를 찾을 수 없습니다."),

--- a/src/main/java/com/gongspot/project/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/gongspot/project/domain/place/controller/PlaceController.java
@@ -52,7 +52,10 @@ public class PlaceController {
             @PathVariable("placeId") Long placeId,
             @RequestParam(name = "page", defaultValue = "0") int page) {
 
-        ReviewResponseDTO.GetReviewListDTO result = reviewQueryService.getReviewList(placeId, page);
+        User user = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Long userId = user.getId();
+
+        ReviewResponseDTO.GetReviewListDTO result = reviewQueryService.getReviewList(placeId, page, userId);
         return ApiResponse.onSuccess(result);
     }
 

--- a/src/main/java/com/gongspot/project/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/gongspot/project/domain/review/controller/ReviewController.java
@@ -49,4 +49,14 @@ public class ReviewController {
         reviewCommandService.deleteReviewByAdmin(reviewId);
         return ApiResponse.onSuccess();
     }
+
+    @PatchMapping("/{reviewId}")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "내 리뷰 삭제", description = "본인의 리뷰를 삭제합니다.")
+    public ApiResponse<Void> deleteMyReview(@PathVariable("reviewId") Long reviewId) {
+        User user = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Long userId = user.getId();
+        reviewCommandService.softDeleteReview(userId, reviewId);
+        return ApiResponse.onSuccess();
+    }
 }

--- a/src/main/java/com/gongspot/project/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/gongspot/project/domain/review/controller/ReviewController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -38,6 +39,14 @@ public class ReviewController {
         Long userId = user.getId();
 
         reviewCommandService.saveReview(userId, placeId, review, reviewPictures);
+        return ApiResponse.onSuccess();
+    }
+
+    @DeleteMapping("/admin/{reviewId}")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @Operation(summary = "리뷰 삭제 (관리자)", description = "관리자가 리뷰를 삭제합니다.")
+    public ApiResponse<Void> deleteReviewByAdmin(@PathVariable("reviewId") Long reviewId) {
+        reviewCommandService.deleteReviewByAdmin(reviewId);
         return ApiResponse.onSuccess();
     }
 }

--- a/src/main/java/com/gongspot/project/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/com/gongspot/project/domain/review/converter/ReviewConverter.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 
 public class ReviewConverter {
 
-    public static ReviewResponseDTO.GetReviewDTO toGetReviewDTO(Review review, List<Media> reviewMediaList) {
+    public static ReviewResponseDTO.GetReviewDTO toGetReviewDTO(Review review, List<Media> reviewMediaList, Long currentUserId) {
 
         List<String> imageUrls = new ArrayList<>();
         if (reviewMediaList != null && !reviewMediaList.isEmpty()) {
@@ -28,6 +28,7 @@ public class ReviewConverter {
                     .map(Media::getUrl)
                     .collect(Collectors.toList());
         }
+        Boolean isMyReview = review.getUser().getId().equals(currentUserId);
 
         return ReviewResponseDTO.GetReviewDTO.builder()
                 .reviewId(review.getId())
@@ -38,6 +39,7 @@ public class ReviewConverter {
                 .rating(review.getRating())
                 .reviewImageUrl(imageUrls)
                 .content(review.getContent())
+                .isMyReview(isMyReview)
                 .build();
     }
 
@@ -166,7 +168,8 @@ public class ReviewConverter {
             Double averageRating,
             List<ReviewResponseDTO.CategoryCountDTO> categoryList,
             Map<Integer, Long> ratingCounts,
-            int totalReviewCount
+            int totalReviewCount,
+            Long currentUserId
     ) {
 
         Map<Long, List<Media>> reviewMediaMap = mediaList.stream()
@@ -174,7 +177,7 @@ public class ReviewConverter {
 
 
         List<ReviewResponseDTO.GetReviewDTO> reviewDTOs = reviews.stream()
-                .map(review -> toGetReviewDTO(review, reviewMediaMap.getOrDefault(review.getId(), new ArrayList<>())))
+                .map(review -> toGetReviewDTO(review, reviewMediaMap.getOrDefault(review.getId(), new ArrayList<>()),currentUserId))
                 .collect(Collectors.toList());
 
         return ReviewResponseDTO.GetReviewListDTO.builder()

--- a/src/main/java/com/gongspot/project/domain/review/dto/ReviewResponseDTO.java
+++ b/src/main/java/com/gongspot/project/domain/review/dto/ReviewResponseDTO.java
@@ -18,6 +18,7 @@ public class ReviewResponseDTO {
         Integer rating;
         List<String> reviewImageUrl;
         String content;
+        Boolean isMyReview;
     }
 
     @Builder

--- a/src/main/java/com/gongspot/project/domain/review/entity/Review.java
+++ b/src/main/java/com/gongspot/project/domain/review/entity/Review.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -57,6 +58,9 @@ public class Review extends BaseEntity {
 
     @Column(name = "content", length = 500)
     private String content;
+
+    @Column(name = "is_deleted")
+    private Boolean isDeleted = false;
 
     @OneToMany(mappedBy = "review", cascade = CascadeType.ALL)
     private List<Media> mediaList;

--- a/src/main/java/com/gongspot/project/domain/review/service/ReviewCommandService.java
+++ b/src/main/java/com/gongspot/project/domain/review/service/ReviewCommandService.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface ReviewCommandService {
     void saveReview(Long userId, Long placeId, ReviewRequestDTO.ReviewRegisterDTO reqDTO, List<MultipartFile> reviewPictures);
     void deleteReviewByAdmin(Long reviewId);
+    void softDeleteReview(Long userId, Long reviewId);
 }

--- a/src/main/java/com/gongspot/project/domain/review/service/ReviewCommandService.java
+++ b/src/main/java/com/gongspot/project/domain/review/service/ReviewCommandService.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface ReviewCommandService {
     void saveReview(Long userId, Long placeId, ReviewRequestDTO.ReviewRegisterDTO reqDTO, List<MultipartFile> reviewPictures);
+    void deleteReviewByAdmin(Long reviewId);
 }

--- a/src/main/java/com/gongspot/project/domain/review/service/ReviewCommandServiceImpl.java
+++ b/src/main/java/com/gongspot/project/domain/review/service/ReviewCommandServiceImpl.java
@@ -21,6 +21,7 @@ import com.gongspot.project.global.aws.s3.AmazonS3Manager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -84,5 +85,13 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
         } catch (DataIntegrityViolationException e) {
             throw new BusinessException(ErrorStatus.REVIEW_SAVE_FAIL);
         }
+    }
+
+    @Transactional
+    public void deleteReviewByAdmin(Long reviewId) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new BusinessException(ErrorStatus.REVIEW_NOT_FOUND));
+
+        reviewRepository.delete(review);
     }
 }

--- a/src/main/java/com/gongspot/project/domain/review/service/ReviewCommandServiceImpl.java
+++ b/src/main/java/com/gongspot/project/domain/review/service/ReviewCommandServiceImpl.java
@@ -94,4 +94,17 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
 
         reviewRepository.delete(review);
     }
+
+    @Transactional
+    public void softDeleteReview(Long userId, Long reviewId) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new BusinessException(ErrorStatus.REVIEW_NOT_FOUND));
+
+        if (!review.getUser().getId().equals(userId)) {
+            throw new BusinessException(ErrorStatus.UNAUTHORIZED_REVIEW_DELETION);
+        }
+
+        review.setIsDeleted(true);
+        reviewRepository.save(review);
+    }
 }

--- a/src/main/java/com/gongspot/project/domain/review/service/ReviewQueryService.java
+++ b/src/main/java/com/gongspot/project/domain/review/service/ReviewQueryService.java
@@ -4,5 +4,5 @@ import com.gongspot.project.domain.review.dto.ReviewResponseDTO;
 
 public interface ReviewQueryService {
     ReviewResponseDTO.CongestionListDTO getCongestionList(Long userId, Long placeId, int page);
-    ReviewResponseDTO.GetReviewListDTO getReviewList(Long placeId, int page);
+    ReviewResponseDTO.GetReviewListDTO getReviewList(Long placeId, int page,Long currentUserId);
 }

--- a/src/main/java/com/gongspot/project/domain/review/service/ReviewQueryServiceImpl.java
+++ b/src/main/java/com/gongspot/project/domain/review/service/ReviewQueryServiceImpl.java
@@ -44,7 +44,7 @@ public class ReviewQueryServiceImpl implements ReviewQueryService{
     }
 
     @Override
-    public ReviewResponseDTO.GetReviewListDTO getReviewList(Long placeId, int page) {
+    public ReviewResponseDTO.GetReviewListDTO getReviewList(Long placeId, int page, Long currentUserId) {
         Place place = placeRepository.findById(placeId)
                 .orElseThrow(() -> new BusinessException(ErrorStatus.PLACE_NOT_FOUND));
 
@@ -73,7 +73,8 @@ public class ReviewQueryServiceImpl implements ReviewQueryService{
                 averageRating,
                 categoryList,
                 ratingCounts,
-                allReviews.size()
+                allReviews.size(),
+                currentUserId
         );
     }
 


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- fix/129

## ⚡️ 작업동기

- 관리자가 리뷰를 삭제하는 api -> 하드 딜리트
- 사용자가 본인 리뷰 삭제하는 api -> 소프트 딜리트 
- 장소의 리뷰목록 조회에서 내가 쓴 리뷰인지 알수있게 boolean값 추가

## 🔑 주요 변경사항

- DELETE  /reviews/admin/{reviewId}
- DELETE /reviews/{reviewid}

refactor
- GET /places/{placeId}/reviews 

## 💡 관련 이슈

- #129 

