### PR TITLE
[Fix] 리뷰 목록 반환에서 시간 반환 수정 , closes #131

### DIFF
--- a/src/main/java/com/gongspot/project/domain/place/converter/PlaceConverter.java
+++ b/src/main/java/com/gongspot/project/domain/place/converter/PlaceConverter.java
@@ -24,8 +24,8 @@ public class PlaceConverter {
                         .nickname(review.getUser().getNickname())
                         .profileImageUrl(review.getUser().getProfileImg())
                         .congestion(mapCongestionToString(review.getCongestion()))
-                        .daytime(toRelativeDaytime(review.getDatetime()))
-                        .datetime(toRelativeDateString(review.getDatetime()))
+                        .daytime(review.getDatetime().format(DateTimeFormatter.ofPattern("M/d")))
+                        .datetime(review.getDatetime().format(DateTimeFormatter.ofPattern("HH:mm")))
                         .build())
                 .toList();
 
@@ -42,37 +42,6 @@ public class PlaceConverter {
                 .phoneNumber(place.getPhoneNumber())
                 .congestionList(congestionDTOS)
                 .build();
-    }
-    private static String toRelativeDaytime(LocalDateTime dateTime) {
-        long days = Duration.between(dateTime.toLocalDate().atStartOfDay(), LocalDateTime.now().toLocalDate().atStartOfDay()).toDays();
-
-        if (days == 0) return "오늘";
-        else if (days > 0 && days < 4) return days + "일 전";
-        else {
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("M/d");
-            return dateTime.format(formatter);
-        }
-    }
-
-    private static String toRelativeDateString(LocalDateTime dateTime) {
-        LocalDateTime now = LocalDateTime.now();
-
-        Duration duration = Duration.between(dateTime,now);
-
-        long minutes = duration.toMinutes();
-        long hours = duration.toHours();
-
-        if (minutes < 60) {
-            return minutes + "분 전";
-        } else if (hours < 2) {
-            return "1시간 전";
-        } else if (hours < 3) {
-            return "2시간 전";
-        } else if (hours < 4) {
-            return "3시간 전";
-        }else {
-            return dateTime.format(DateTimeFormatter.ofPattern("HH:mm"));
-        }
     }
 
     private static String mapCongestionToString(CongestionEnum congestion) {

--- a/src/main/java/com/gongspot/project/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/com/gongspot/project/domain/review/converter/ReviewConverter.java
@@ -34,7 +34,7 @@ public class ReviewConverter {
                 .userId(review.getUser().getId())
                 .nickname(review.getUser().getNickname())
                 .profileImageUrl(review.getUser().getProfileImg())
-                .datetime(review.getCreatedAt().format(DateTimeFormatter.ofPattern("yy.MM.dd")))
+                .datetime(review.getDatetime().format(DateTimeFormatter.ofPattern("yy.MM.dd")))
                 .rating(review.getRating())
                 .reviewImageUrl(imageUrls)
                 .content(review.getContent())

--- a/src/main/java/com/gongspot/project/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/com/gongspot/project/domain/review/converter/ReviewConverter.java
@@ -49,8 +49,8 @@ public class ReviewConverter {
                 .nickname(review.getUser().getNickname())
                 .profileImageUrl(review.getUser().getProfileImg())
                 .congestion(mapCongestionToString(review.getCongestion()))
-                .daytime(toRelativeDaytime(review.getDatetime()))
-                .datetime(toRelativeDateString(review.getDatetime()))
+                .daytime(review.getDatetime().format(DateTimeFormatter.ofPattern("M/d")))
+                .datetime(review.getDatetime().format(DateTimeFormatter.ofPattern("HH:mm")))
                 .paid(paidStatus)
                 .build();
     }
@@ -202,37 +202,7 @@ public class ReviewConverter {
         }
     }
 
-    private static String toRelativeDaytime(LocalDateTime dateTime) {
-        long days = Duration.between(dateTime.toLocalDate().atStartOfDay(), LocalDateTime.now().toLocalDate().atStartOfDay()).toDays();
 
-        if (days == 0) return "오늘";
-        else if (days > 0 && days < 4) return days + "일 전";
-        else {
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("M/d");
-            return dateTime.format(formatter);
-        }
-    }
-
-    private static String toRelativeDateString(LocalDateTime dateTime) {
-        LocalDateTime now = LocalDateTime.now();
-
-        Duration duration = Duration.between(dateTime,now);
-
-        long minutes = duration.toMinutes();
-        long hours = duration.toHours();
-
-        if (minutes < 60) {
-            return minutes + "분 전";
-        } else if (hours < 2) {
-            return "1시간 전";
-        } else if (hours < 3) {
-            return "2시간 전";
-        } else if (hours < 4) {
-            return "3시간 전";
-        }else {
-            return dateTime.format(DateTimeFormatter.ofPattern("HH:mm"));
-        }
-    }
     private static String toDateString(LocalDate dateTime) {
         String dayOfWeek;
         switch (dateTime.getDayOfWeek()) {


### PR DESCRIPTION
## 🎋 작업중인 브랜치

- fix/131

## ⚡️ 작업동기

- 리뷰목록 반환에서 시간 반환 수정 

## 🔑 주요 변경사항

- GET /places/{placeId}/reviews 에서 리뷰 생성시간에서 장소 방문시간으로 수정 
- GET /places/{placeId}/congestions, /places/{placeId} 에서 혼잡도 계산해서 반환했던것에서 날짜와 시간으로만 반환하도록 수정 

## 💡 관련 이슈

- #131 

